### PR TITLE
Option to save output as text (#10)

### DIFF
--- a/prm_gui.py
+++ b/prm_gui.py
@@ -24,7 +24,7 @@ parser.add_argument('--mock', action='store_true',
                     default=False,
                     help='If true, runs a mock application for debugging purposes.')
 parser.add_argument('--datafiles',
-                    default='/home/mdeltutt/prm_data',
+                    default='',
                     help='Path where data files will be saved.')
 parser.add_argument('--logfile',
                     default='prm_log.txt',
@@ -48,6 +48,8 @@ settings = os.path.join(os.path.dirname(__file__), 'settings.yaml')
 
 with open(settings, encoding="utf-8") as file:
     config = yaml.load(file, Loader=yaml.FullLoader)
+if args.datafiles:
+    config["data_files_path"] = args.datafiles
 print('Config:', yaml.dump(config), sep='\n')
 
 # logger.info(yaml.dump(config))

--- a/sbndprmdaq/manager.py
+++ b/sbndprmdaq/manager.py
@@ -443,23 +443,20 @@ class PrMManager():
             '_data_' +
             timestr
         )
-        dir_name = os.path.join(self._data_files_path, run_name)
-        os.mkdir(dir_name)
 
-        # All in one zipped numpy file
         if self._save_as_npz:
-            np.savez(os.path.join(dir_name, run_name + '.npz'), **out_dict)
+            np.savez(os.path.join(self._data_files_path, run_name + '.npz'), **out_dict)
 
-        # Split into multiple text files
         if self._save_as_txt:
-            for k, v in out_dict.items():
-                file_name = os.path.join(dir_name, run_name + '_' + k + '.txt')
-                if isinstance(v, list):
-                    v = np.stack(v)
-                    np.savetxt(file_name, v[...,np.newaxis] if v.ndim == 1 else v)
-                else:
-                    with open(file_name, 'w', encoding='utf-8') as f:
-                        f.write(str(v))
+            file_name = os.path.join(self._data_files_path, run_name + '.txt')
+            with open(file_name, 'w', encoding='utf-8') as f:
+                for k, v in out_dict.items():
+                    if isinstance(v, list):
+                        v = np.stack(v) # assuming list of arrays
+                        v_str = str(v.tolist()).replace(" ", "")
+                        f.write(k + '=' + v_str + '\n')
+                    else:
+                        f.write(k + '=' + str(v) + '\n')
 
 
     def set_comment(self, comment):

--- a/sbndprmdaq/manager.py
+++ b/sbndprmdaq/manager.py
@@ -445,7 +445,7 @@ class PrMManager():
         )
         dir_name = os.path.join(self._data_files_path, run_name)
         os.mkdir(dir_name)
-        
+
         # All in one zipped numpy file
         if self._save_as_npz:
             np.savez(os.path.join(dir_name, run_name + '.npz'), **out_dict)
@@ -454,11 +454,11 @@ class PrMManager():
         if self._save_as_txt:
             for k, v in out_dict.items():
                 file_name = os.path.join(dir_name, run_name + '_' + k + '.txt')
-                if type(v) == list:
+                if isinstance(v, list):
                     v = np.stack(v)
                     np.savetxt(file_name, v[...,np.newaxis] if v.ndim == 1 else v)
                 else:
-                    with open(file_name, 'w') as f:
+                    with open(file_name, 'w', encoding='utf-8') as f:
                         f.write(str(v))
 
 

--- a/sbndprmdaq/manager.py
+++ b/sbndprmdaq/manager.py
@@ -38,6 +38,8 @@ class PrMManager():
         self._repetitions = {}
 
         self._data_files_path = config['data_files_path']
+        self._save_as_npz = config['save_as_npz']
+        self._save_as_txt = config['save_as_txt']
 
         for prm_id in config['prm_ids']:
             self._data[prm_id] = None
@@ -391,6 +393,9 @@ class PrMManager():
         if self._data_files_path is None:
             self._logger.warning('Cannot save to file, data_files_path not set.')
             return
+        if not self._save_as_npz and not self._save_as_txt:
+            self._logger.warning('Not saving to file, neither save_as_npz or save_as_txt are set')
+            return
 
         out_dict = {}
 
@@ -432,17 +437,29 @@ class PrMManager():
             for k, v in configs.items():
                 out_dict['config_' + k] = v
 
-        file_name = self._data_files_path
-        # file_name = '/home/nfs/mdeltutt/work/purity_monitors/blanche_data_jul2023'
-        file_name += '/sbnd_prm'
-        file_name += str(prm_id)
-        file_name += '_run_'
-        file_name += str(self._run_numbers[prm_id])
-        file_name += '_data_'
-        file_name += timestr
-        file_name += '.npz'
+        run_name = (
+            'sbnd_prm' + str(prm_id) +
+            '_run_' + str(self._run_numbers[prm_id]) +
+            '_data_' +
+            timestr
+        )
+        dir_name = os.path.join(self._data_files_path, run_name)
+        os.mkdir(dir_name)
+        
+        # All in one zipped numpy file
+        if self._save_as_npz:
+            np.savez(os.path.join(dir_name, run_name + '.npz'), **out_dict)
 
-        np.savez(file_name, **out_dict)
+        # Split into multiple text files
+        if self._save_as_txt:
+            for k, v in out_dict.items():
+                file_name = os.path.join(dir_name, run_name + '_' + k + '.txt')
+                if type(v) == list:
+                    v = np.stack(v)
+                    np.savetxt(file_name, v[...,np.newaxis] if v.ndim == 1 else v)
+                else:
+                    with open(file_name, 'w') as f:
+                        f.write(str(v))
 
 
     def set_comment(self, comment):

--- a/settings.yaml
+++ b/settings.yaml
@@ -54,7 +54,8 @@ data_files_path: '/home/nfs/sbndprm/purity_monitor_data/'
 # data_files_path: '/sbnd/data/purity_monitors/'
 # data_files_path: '/home/nfs/mdeltutt/work/purity_monitors/data/'
 # data_files_path: '/Users/mdeltutt/Work/SBND/Purity Monitors/communication/'
-
+save_as_npz: true
+save_as_txt: true
 
 arduino_address: '/dev/arduino'
 arduino_pin: 7


### PR DESCRIPTION
closes #11  

Each run makes a directory in the output path so that the output data can be written in multiple text files. Thought this would be the simplest way to have data as text.