### PR TITLE
slow control integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ paramiko
 sshtunnel
 requests
 rich
+pyepics

--- a/sbndprmdaq/manager.py
+++ b/sbndprmdaq/manager.py
@@ -573,9 +573,9 @@ class PrMManager():
             out_dict (dict): Data from run.
         '''
         if prm_id == 1:
-            prm = 'tpcshort'
-        elif prm_id == 2:
             prm = 'tpclong'
+        elif prm_id == 2:
+            prm = 'tpcshort'
         elif prm_id == 3:
             prm = 'inline'
         else:

--- a/sbndprmdaq/manager.py
+++ b/sbndprmdaq/manager.py
@@ -346,7 +346,7 @@ class PrMManager():
 
         for rep in range(self._repetitions[prm_id]):
             self._logger.info(f'*** Repetition number {rep}.')
-            self._logger.info('Start capture for  {prm_id}.')
+            self._logger.info(f'Start capture for {prm_id}.')
             self._prm_digitizer.start_capture(prm_id)
             self._logger.info(f'Check capture for  {prm_id}.')
             status = self._prm_digitizer.check_capture(prm_id)
@@ -575,14 +575,26 @@ class PrMManager():
             prm = 'tpcshort'
         elif prm_id == 2:
             prm = 'tpclong'
-        elif prm == 3:
+        elif prm_id == 3:
             prm = 'inline'
         else:
             raise ValueError('prm_id {} invalid'.format(prm_id))
+        
+        pvs = [
+            'sbnd_prm_{}_hv/anode_voltage',
+            'sbnd_prm_{}_hv/anodegrid_voltage',
+            'sbnd_prm_{}_hv/cathode_voltage'
+        ]
+        res = []
+        for pv in pvs:
+            res.append(epics.caput(pv.format(prm), out_dict['hv_anode']))
 
-        epics.caput('sbnd_prm_' + prm + '_hv/anode_voltage', out_dict['hv_anode'])
-        epics.caput('sbnd_prm_' + prm + '_hv/anodegrid_voltage', out_dict['hv_anodegrid'])
-        epics.caput('sbnd_prm_' + prm + '_hv/cathode_voltage', out_dict['hv_cathode'])
+        if all(res):
+            self._logger.info('All EPICS updates successful for PrM {}'.format(prm_id))
+        elif any(res):
+            self._logger.info('Some EPICS updates failed for PrM {}'.format(prm_id))
+        else:
+            self._logger.info('All EPICS updates failed for PrM {}'.format(prm_id))
 
     def set_comment(self, comment):
         '''

--- a/sbndprmdaq/manager.py
+++ b/sbndprmdaq/manager.py
@@ -432,7 +432,8 @@ class PrMManager():
                 'time': data['time'],
             }
             out_dict = self.save_data(data['prm_id'])
-            self.output_to_epics(data['prm_id'], out_dict)
+            if out_dict is not None:
+                self.output_to_epics(data['prm_id'], out_dict)
             self._logger.info(f'Saved data for PrM {data["prm_id"]}.')
         else:
             self._logger.info(f'Bad capture, no data to save for PrM {data["prm_id"]}.')
@@ -493,17 +494,17 @@ class PrMManager():
 
         if self._data_files_path is None:
             self._logger.warning('Cannot save to file, data_files_path not set.')
-            return
+            return None
         if not self._save_as_npz and not self._save_as_txt:
             self._logger.warning('Not saving to file, neither save_as_npz or save_as_txt are set')
-            return
+            return None
 
         out_dict = {}
 
         timestr = time.strftime("%Y%m%d-%H%M%S")
 
         if self._data[prm_id] is None:
-            return
+            return None
 
         for ch in self._data[prm_id].keys():
             out_dict[f'ch_{ch}'] = self._data[prm_id][ch]
@@ -578,23 +579,23 @@ class PrMManager():
         elif prm_id == 3:
             prm = 'inline'
         else:
-            raise ValueError('prm_id {} invalid'.format(prm_id))
-        
+            raise ValueError(f'prm_id {prm_id} invalid')
+
         pvs = [
-            'sbnd_prm_{}_hv/anode_voltage',
-            'sbnd_prm_{}_hv/anodegrid_voltage',
-            'sbnd_prm_{}_hv/cathode_voltage'
+            f'sbnd_prm_{prm}_hv/anode_voltage',
+            f'sbnd_prm_{prm}_hv/anodegrid_voltage',
+            f'sbnd_prm_{prm}_hv/cathode_voltage'
         ]
         res = []
         for pv in pvs:
-            res.append(epics.caput(pv.format(prm), out_dict['hv_anode']))
+            res.append(epics.caput(pv, out_dict['hv_anode']))
 
         if all(res):
-            self._logger.info('All EPICS updates successful for PrM {}'.format(prm_id))
+            self._logger.info(f'All EPICS updates successful for PrM {prm_id}')
         elif any(res):
-            self._logger.info('Some EPICS updates failed for PrM {}'.format(prm_id))
+            self._logger.info(f'Some EPICS updates failed for PrM {prm_id}')
         else:
-            self._logger.info('All EPICS updates failed for PrM {}'.format(prm_id))
+            self._logger.info(f'All EPICS updates failed for PrM {prm_id}')
 
     def set_comment(self, comment):
         '''

--- a/sbndprmdaq/mock_manager.py
+++ b/sbndprmdaq/mock_manager.py
@@ -29,3 +29,21 @@ class MockPrMManager(PrMManager):
 
     def exit(self):
         pass
+
+    #pylint: disable=duplicate-code
+    def _thread_data(self, data):
+        '''
+        Remove output_to_epics call for testing
+        '''
+        self._logger.info(f'Got data for PrM {data["prm_id"]}.')
+
+        if data['status']:
+            self._data[data['prm_id']] = {
+                'A': data['A'],
+                'B': data['B'],
+                'time': data['time'],
+            }
+            _ = self.save_data(data['prm_id'])
+            self._logger.info(f'Saved data for PrM {data["prm_id"]}.')
+        else:
+            self._logger.info(f'Bad capture, no data to save for PrM {data["prm_id"]}.')


### PR DESCRIPTION
Write run results to new epics purity monitor channels.

I added the following EPICS channels for purity monitors:
```
sbnd_prm_{inline,tpcshort,tpclong}_hv/anode_voltage
sbnd_prm_{inline,tpcshort,tpclong}_hv/cathode_voltage
sbnd_prm_{inline,tpcshort,tpclong}_hv/anodegrid_voltage
sbnd_prm_{inline,tpcshort,tpclong}_signal/QA
sbnd_prm_{inline,tpcshort,tpclong}_signal/QC
sbnd_prm_{inline,tpcshort,tpclong}_signal/drift_time
sbnd_prm_{inline,tpcshort,tpclong}_signal/lifetime
```
Currently only writing out to the HV ones, we can easily add more as needed. They are not currently linked up to the archiving system or the alarm system but we can do that easily also.

This PR requires `pyepics`, which I added to the requirements and installed on the `sbnd-prm01` system python3 also.

Let me know what you think @marcodeltutto 